### PR TITLE
Disable documentation for tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,5 +332,4 @@ ASALocalRun/
 # Project specific 
 
 config.wyam.*
-docs/input/tasks/
 BuildArtifacts/

--- a/setup.cake
+++ b/setup.cake
@@ -11,7 +11,8 @@ BuildParameters.SetParameters(
     repositoryName: "BBT.Maybe",
     appVeyorAccountName: "BBTSoftwareAG",
     shouldPublishMyGet: false,
-    shouldRunCodecov: false);
+    shouldRunCodecov: false,
+    shouldDeployGraphDocumentation: false);
 
 BuildParameters.PrintParameters(Context);
 


### PR DESCRIPTION
Disable documentation for tasks of the build script in the documentation site