### PR TITLE
Fix link to API documentation

### DIFF
--- a/docs/input/_Navbar.cshtml
+++ b/docs/input/_Navbar.cshtml
@@ -2,7 +2,7 @@
     List<Tuple<string, string>> pages = new List<Tuple<string, string>>
     {
         Tuple.Create("Documentation", Context.GetLink("docs")),
-        Tuple.Create("API", Context.GetLink("api/BBT.Maybe"))
+        Tuple.Create("API", Context.GetLink("api/BBT.MaybePattern"))
     };
     foreach(Tuple<string, string> p in pages)
     {


### PR DESCRIPTION
Fixes the link to the API documentation due to the namespace renaming