### PR TITLE
Use correct heading levels for TOC generation

### DIFF
--- a/docs/input/docs/getting-started/principles.md
+++ b/docs/input/docs/getting-started/principles.md
@@ -10,12 +10,12 @@ A possible solution is implementing a null condition for each reference call wit
 This contradicts the fail fast approach, makes code less readable and increases cyclomatic complexity.
 A better approach is to introduce a functional option type.
 
-## Advantages
+# Advantages
 
 * Explicit method signature: Declaration of optional reference type argument and return value through a typified construct make method documentation redundant.
 * Prevention of null reference exceptions: Straight access to the nullable reference value is not possible, an action for the not-null case is called instead.
 
-## Implementation details
+# Implementation details
 
 * Maybe is a value type
 * Default of maybe is the null case

--- a/docs/input/docs/getting-started/whymaybe.md
+++ b/docs/input/docs/getting-started/whymaybe.md
@@ -6,13 +6,13 @@ Description: Introduction to BBT.Maybe, what problems are solved and how it's di
 
 BBT.Maybe is an implementation of the functional option type pattern.
 
-## Features
+# Features
 
 * Make nullable references explicit
 * Prevent null reference exceptions on reference calls
 * Provide an option type with broad usage over all layers of code
 
-## Advantages over similar libraries
+# Advantages over similar libraries
 
 * Prevent access to null value, therefore no direct access is offered.
 * Implementation of maybe for both optional reference and nullable value types

--- a/docs/input/docs/usage/examples.md
+++ b/docs/input/docs/usage/examples.md
@@ -4,7 +4,7 @@ Title: Examples
 Description: Example usage of BBT.Maybe
 ---
 
-## Usage of factory methods
+# Usage of factory methods
 
 Maybe values are created using factory methods provided by Maybe. Methods with arguments for reference are available (`Maybe.Some<T>`).
 For the none case parameterless methods can be used (`Maybe.None<T>`).
@@ -26,7 +26,7 @@ var maybeNumber = Maybe.SomeStruct<int>(number);
 var maybeNumber2 = Maybe.NoneStruct<int>();
 ```
 
-## Optional properties
+# Optional properties
 
 Maybe is useful for optional properties. The default implementation of maybe represents the null case, therefore optional properties of type `Maybe<T>` are representing the null case too and must not be initialized.
 
@@ -56,7 +56,7 @@ public void Foo(bool flag, Maybe<A> maybeA = default)
 }
 ```
 
-## Projection method
+# Projection method
 
 Maybe provides a projection method (Some method) with an argument of type Func<T, TProjected>.
 The usage is similar to the null propagation operator.

--- a/docs/input/docs/usage/obtain.md
+++ b/docs/input/docs/usage/obtain.md
@@ -4,7 +4,7 @@ Title: Obtain
 Description: Obtain BBT.Maybe
 ---
 
-## Nuget
+# Nuget
 
 BBT.Maybe is available as NuGet package. See [https://www.nuget.org/packages/BBT.Maybe].
 


### PR DESCRIPTION
Wyam requires headings to start with H1 that headings appear in the TOC on the right sidebar.