### PR TITLE
(GH-67) Use embedded icon in NuGet package

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,10 @@ image: Visual Studio 2017
 #---------------------------------#
 #  Build Script                   #
 #---------------------------------#
+install:
+  # Update to latest NuGet version since we require 5.3.0 for embedded icon
+  - ps: nuget update -self
+  
 build_script:
   - ps: .\build.ps1 -Target AppVeyor
 

--- a/nuspec/nuget/BBT.MaybePattern.nuspec
+++ b/nuspec/nuget/BBT.MaybePattern.nuspec
@@ -10,7 +10,7 @@
     <description>An option type for .NET.</description>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/bbtsoftware/BBT.Maybe/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/bbtsoftware/BBT.Maybe/de51feaf705f283540a21b1cb7c317ed36cbd03e/nuspec/nuget/icon.png</iconUrl>
+    <icon>icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <repository type="git" url="https://github.com/bbtsoftware/BBT.Maybe.git"/>
     <copyright>Copyright © BBT Software AG</copyright>
@@ -18,6 +18,7 @@
     <releaseNotes>https://github.com/bbtsoftware/BBT.Maybe/releases/tag/3.0.0</releaseNotes>
   </metadata>
   <files>
+    <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
     <file src="netstandard2.0\BBT.MaybePattern.dll" target="lib\netstandard2.0" />
     <file src="netstandard2.0\BBT.MaybePattern.pdb" target="lib\netstandard2.0" />
     <file src="netstandard2.0\BBT.MaybePattern.xml" target="lib\netstandard2.0" />


### PR DESCRIPTION
Change to embedded icon in NuGet package

Fixes #67 